### PR TITLE
Fix getting the device name from partition name

### DIFF
--- a/fatresize.c
+++ b/fatresize.c
@@ -140,9 +140,21 @@ get_partnum(char *dev)
     return pnum ? pnum : 1;
 }
 
+/* Code parts have been taken from _ped_device_probe(). */
+static void
+probe_device(PedDevice **dev, const char *path)
+{
+    ped_exception_fetch_all();
+    *dev = ped_device_get(path);
+    if (!*dev)
+	ped_exception_catch();
+    ped_exception_leave_all();
+}
+
 static char *
 get_devname(char *dev)
 {
+    PedDevice *peddev = NULL;
     char *devname;
     char *p;
 
@@ -160,6 +172,20 @@ get_devname(char *dev)
 	if (p)
 	    strcpy(p, p+5);
     }
+
+    /* check if the device really exists */
+    while (*p && *p != '/' && !peddev)
+    {
+	devname[p-dev+1] = '\0';
+	probe_device(&peddev, devname);
+	p--;
+    }
+    if (!peddev)
+    {
+	free(devname);
+	return NULL;
+    }
+    ped_device_destroy(peddev);
 
     return devname;
 }
@@ -412,7 +438,7 @@ main(int argc, char **argv)
 
     if (!opts.dev)
     {
-	fprintf(stderr, "You must specify exactly one device.\n");
+	fprintf(stderr, "You must specify exactly one existing device.\n");
 	return 1;
     }
     else if (!opts.size && !opts.info)


### PR DESCRIPTION
There are many partition device names like e.g. /dev/mmcblk0p1 where it is not enough to trim the trailing digits to get the disk device name. So try to open the device and trim further trailing characters
until it can be opened. Return NULL in get_devname() if the partition name is invalid. Also adapt the usage warning to show that an existing device name has to be provided.

References: boo#959181
Fixes #2