### PR TITLE
Allow setting maximum size by keyword "max"

### DIFF
--- a/fatresize.sgml
+++ b/fatresize.sgml
@@ -103,7 +103,7 @@ manpage.1: manpage.sgml
         </term>
         <listitem>
           <para>
-Resize volume to SIZE[k|M|G|ki|Mi|Gi] bytes
+Resize volume to SIZE[k|M|G|ki|Mi|Gi] bytes or "max"
 </para>
         </listitem>
       </varlistentry>
@@ -167,7 +167,7 @@ fatresize -s 2G /dev/evms/hdb2
 </para>
 
 <para>
-fatresize -q -s 3G /dev/hde6
+fatresize -q -s max /dev/hde6
 </para>
 
 <para>


### PR DESCRIPTION
Setting the maximum size requires two steps at the moment:
1. get the maximum size with the info option
2. set the maximum size from the info option

It would be much nicer to combine this. So introduce the keyword
"max" for the size. Use LLONG_MAX internally and reuse code parts
from the info option to set the actual maximum size. Update help
text and man page as well.

Looks like this:
$ fatresize -s max /dev/sdb1

Fixes #5