### PR TITLE
Two corner-case fixes

### DIFF
--- a/fatresize.c
+++ b/fatresize.c
@@ -207,8 +207,8 @@ static int get_device(char *dev) {
       free(devname);
       return 0;
     }
-  } else {
-    opts.pnum = get_partnum(devname);
+  } else if (opts.pnum < 0) {
+    opts.pnum = get_partnum(dev);
   }
   ped_device_destroy(peddev);
   opts.device = devname;

--- a/fatresize.c
+++ b/fatresize.c
@@ -621,6 +621,11 @@ int main(int argc, char **argv) {
     opts.size = constraint->max_size * dev->sector_size;
     ped_constraint_destroy(constraint);
   }
+  if (opts.size >= dev->sector_size * part_geom.length) {
+     printf("Specified size (%llu) equals or exceeds partition size (%llu)\n",
+            opts.size, dev->sector_size * part_geom.length);
+     opts.size = (dev->sector_size * (part_geom.length - 1));
+  }
 
   start = part_geom.start;
   printd(3, "ped_geometry_new(%llu)\n", start);


### PR DESCRIPTION
I found these when I was working with a USB stick with multiple FAT32 partitions and I wanted to resize the last one to fill the remainder of the space on the flash drive.  Once merged, these allow calls like the following to work:

```
# fatresize -n 3 -s 23415733760 /dev/sda
# fatresize -n 3 -s 23416MB /dev/sda
# fatresize -s 23415733760 /dev/sda3
```

The first two would previously fail with the assertion noted in the commit log while the third would complain about overlapping partitions because it would incorrectly deduce that the first partition was the one to be resized since it also happened to match the other conditions (it is also a fat32 partition and `devname` was modified during use).