### PR TITLE
Honour partition number from originally supplied device

### DIFF
--- a/fatresize.c
+++ b/fatresize.c
@@ -208,7 +208,7 @@ static int get_device(char *dev) {
       return 0;
     }
   } else {
-    opts.pnum = get_partnum(devname);
+    opts.pnum = get_partnum(dev);
   }
   ped_device_destroy(peddev);
   opts.device = devname;


### PR DESCRIPTION
Use the command-line parameter to determine the partition number, not the stripped device - Issue #31 

I'm about 90% sure it doesn't make sense to use the `devname` which will have had the `p2` prefix removed.  I have an alternate fix if there is a condition where `devname` _should_ be preferred