### PR TITLE
Bugfix wrong partition extended

### DIFF
--- a/fatresize.c
+++ b/fatresize.c
@@ -157,7 +157,7 @@ static int get_partnum(char *dev) {
   }
 
   pnum = atoi(p + 1);
-  return pnum ? pnum : 1;
+  return pnum ? pnum : -1;
 }
 
 static int get_device(char *dev) {
@@ -208,7 +208,12 @@ static int get_device(char *dev) {
       return 0;
     }
   } else {
-    opts.pnum = get_partnum(dev);
+    int pnum = get_partnum(devname);
+    if (pnum < 0)
+       pnum = get_partnum(dev);
+    if (pnum < 0)
+      pnum = 1; /* Original code returned 1 in this case */
+    opts.pnum = pnum;
   }
   ped_device_destroy(peddev);
   opts.device = devname;

--- a/fatresize.c
+++ b/fatresize.c
@@ -208,7 +208,7 @@ static int get_device(char *dev) {
       return 0;
     }
   } else {
-    opts.pnum = get_partnum(devname);
+    opts.pnum = get_partnum(dev);
   }
   ped_device_destroy(peddev);
   opts.device = devname;


### PR DESCRIPTION
This is a more complicated fix incorporating the change in PR-#32 for issue #31 

This assumes there was a reason for preferring reading the partnum from `devname` instead of `dev` - it falls back to dev if not resolvable, and falls back to 1 (like the old `get_partnum()`) if nothing works out.