### PR TITLE
fix build with autoconf 2.72

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,9 @@ AC_CHECK_FUNCS([memset strtoll])
 
 # Check for LFS
 AC_SYS_LARGEFILE
-CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=${ac_cv_sys_file_offset_bits}"
+
+# not needed in autoconf 2.72 as long as AC_SYS_LARGEFILE is called
+# CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=${ac_cv_sys_file_offset_bits}"
 
 dnl libparted
 # hack


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2256775

This component makes use of autoconf internals in it configure.ac, which leads to a build failure with 2.72 since the internals have changed.

As far as "AC_SYS_LARGEFILE" is called, there is no need to modify the CFLAGS as that is done by autoconf if necessary.